### PR TITLE
Make Methods local

### DIFF
--- a/PlayTime/playTime.lua
+++ b/PlayTime/playTime.lua
@@ -1,4 +1,4 @@
-Methods = {}
+local Methods = {}
 local playTimeGuiID = 01245780
 Methods.UpdatePlayTime = function()
     for pid, player in pairs(Players) do


### PR DESCRIPTION
A script's `Methods` shouldn't be global - it'll work if only 1 script run by the server has a non-local `Methods`, but if there are 2, one script's will overwrite the others and cause crashes.